### PR TITLE
feat: adds timestamp and auto generate createdAt and updatedAt fields

### DIFF
--- a/packages/common/__test__/common-basic.test.ts
+++ b/packages/common/__test__/common-basic.test.ts
@@ -32,6 +32,8 @@ const sampleData = {
   },
   enum: 'type1',
   smallint: 12,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
 };
 
 // TODO: Test case for creating with ID
@@ -116,6 +118,7 @@ describe('Basic CRUD', () => {
       const instance = ezb.getInternalInstance();
       const updatedData = { ...sampleData };
       updatedData.varchar = 'This is a new string';
+      updatedData.updatedAt = Date.now();
       // @ts-ignore
       const response = await instance._server.inject({
         method: 'PATCH',
@@ -206,6 +209,8 @@ describe('Basic CRUD', () => {
     varchar: '',
     int: 0,
     boolean: false,
+    createdAt: Date.now(),
+    updatedAt: Date.now()
   };
   describe('Creation Edge Case', () => {
     test('Creating an object with nullish values should return the nullish values', async () => {
@@ -230,7 +235,7 @@ describe('Basic CRUD', () => {
 
   describe('Typeorm Error Handling', () => {
     test('TypeORM errors should be returned verbosely when facing them', async () => {
-      const payload = { idNumber: 1 };
+      const payload = { idNumber: 1, createdAt: Date.now(), updatedAt: Date.now() };
       await ezb.inject({
         method: 'POST',
         url: '/SampleUnique',

--- a/packages/common/src/model/repo/ez-repo.ts
+++ b/packages/common/src/model/repo/ez-repo.ts
@@ -296,11 +296,11 @@ function schemaToEntityOptions(schema: ModelSchema) {
     },
     createdAt: {
       type: 'datetime',
-      createDate: true
+      createDate: true,
     },
     updatedAt: {
       type: 'datetime',
-      updateDate: true
+      updateDate: true,
     }
   };
   const relations: { [key: string]: EntitySchemaRelationOptions } = {};

--- a/packages/common/src/model/repo/ez-repo.ts
+++ b/packages/common/src/model/repo/ez-repo.ts
@@ -294,15 +294,14 @@ function schemaToEntityOptions(schema: ModelSchema) {
       primary: true,
       generated: true,
     },
-    // URGENT TODO: Figure out why TypeORM is not automatically generating the createdAt and updatedAt dates
-    // createdAt: {
-    //     type: 'date',
-    //     createDate: true
-    // },
-    // updatedAt: {
-    //     type: 'date',
-    //     updateDate: true
-    // }
+    createdAt: {
+      type: 'datetime',
+      createDate: true
+    },
+    updatedAt: {
+      type: 'datetime',
+      updateDate: true
+    }
   };
   const relations: { [key: string]: EntitySchemaRelationOptions } = {};
   Object.entries(schema).forEach(([key, value]) => {

--- a/packages/openapi/__test__/__snapshots__/openapi.test.ts.snap
+++ b/packages/openapi/__test__/__snapshots__/openapi.test.ts.snap
@@ -20,6 +20,12 @@ Object {
     },
     "def-1": Object {
       "properties": Object {
+        "createdAt": Object {
+          "type": "number",
+        },
+        "updatedAt": Object {
+          "type": "number",
+        },
         "var1": Object {
           "type": "string",
         },
@@ -28,6 +34,8 @@ Object {
         },
       },
       "required": Array [
+        "createdAt",
+        "updatedAt",
         "var1",
         "var2",
       ],
@@ -36,6 +44,12 @@ Object {
     },
     "def-2": Object {
       "properties": Object {
+        "createdAt": Object {
+          "type": "number",
+        },
+        "updatedAt": Object {
+          "type": "number",
+        },
         "var1": Object {
           "type": "string",
         },
@@ -44,6 +58,8 @@ Object {
         },
       },
       "required": Array [
+        "createdAt",
+        "updatedAt",
         "var1",
         "var2",
       ],
@@ -52,6 +68,12 @@ Object {
     },
     "def-3": Object {
       "properties": Object {
+        "createdAt": Object {
+          "type": "number",
+        },
+        "updatedAt": Object {
+          "type": "number",
+        },
         "var1": Object {
           "type": "string",
         },
@@ -64,6 +86,12 @@ Object {
     },
     "def-4": Object {
       "properties": Object {
+        "createdAt": Object {
+          "type": "number",
+        },
+        "updatedAt": Object {
+          "type": "number",
+        },
         "var1": Object {
           "type": "string",
         },
@@ -76,7 +104,13 @@ Object {
     },
     "def-5": Object {
       "properties": Object {
+        "createdAt": Object {
+          "type": "number",
+        },
         "id": Object {
+          "type": "number",
+        },
+        "updatedAt": Object {
           "type": "number",
         },
         "var1": Object {

--- a/packages/openapi/__test__/openapi.test.ts
+++ b/packages/openapi/__test__/openapi.test.ts
@@ -56,6 +56,8 @@ describe('Basic Usage', () => {
     const dummyModel = new EzModel('model', {
       var1: Type.VARCHAR,
       var2: Type.VARCHAR,
+      createdAt: Type.DOUBLE,
+      updatedAt: Type.DOUBLE
     });
 
     app.addApp('model', dummyModel);


### PR DESCRIPTION
`type: 'timestamp with time zone'`

the above is type is not by "better-sqlite3" so we are using `type:datetime` as it has date-time with timezone.